### PR TITLE
Add LinkedClaims lexicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Lexicons are how custom data types are described in AT Protocol. This list is a 
 * Creator [@mchal.lol](https://bsky.app/profile/did:plc:w3aonw33w3mz3mwws34x5of6)
 * Namespace `lol.atmo.*`
 
+## LinkedClaims
+* App https://linkedclaims.com
+* Bluesky Account [@linkedclaims.com](https://bsky.app/profile/linkedclaims.com)
+* GitHub https://github.com/Cooperation-org/claim-atproto
+* Namespace `com.linkedclaims.*`
+
 # Bluesky
 
 The Bluesky team create and manage the Bluesky Lexicon plus steward the atproto core Lexicons and a few related ones like chat and ozone moderation tools.


### PR DESCRIPTION
Adds LinkedClaims to the list. A protocol for verifiable claims about any URI-addressable subject, based on the DIF Labs LinkedClaims spec. Claims are immutable signed assertions that can reference each other, enabling a cross-system web of trust.

* https://linkedclaims.com
* Namespace: `com.linkedclaims.*`
* Lexicon store: https://lexicon.store/com.atproto.lexicon.schema/com.linkedclaims.claim
* Bluesky: @linkedclaims.com
* License: MIT

| Lexicon ID | Description |
|---|---|
| `com.linkedclaims.claim` | A verifiable claim about any URI-addressable subject, with subject, claimType, evidence, source, and optional embedded cryptographic proof |